### PR TITLE
Update jwt-hardcode rule

### DIFF
--- a/javascript/jwt-hardcode/example1.js
+++ b/javascript/jwt-hardcode/example1.js
@@ -2,8 +2,8 @@
 const config = require('./app.config');
 const privateMethods = {
     initialize(USER) {
-        const router = require('express').Router(),
         // ruleid: hardcoded-jwt-secret
+        const router = require('express').Router(),
         jwt = require('jsonwebtoken');
         if (config) {
             router.route('/register').post((req, res) => {

--- a/javascript/jwt-hardcode/example2.js
+++ b/javascript/jwt-hardcode/example2.js
@@ -1,7 +1,7 @@
 (()=> {
 
   'use strict';
-
+// ruleid: hardcoded-jwt-secret
   let User = require('./user'),
   jwt      = require('jsonwebtoken');
 

--- a/javascript/jwt-hardcode/jwt-hardcode.js
+++ b/javascript/jwt-hardcode/jwt-hardcode.js
@@ -1,5 +1,5 @@
 "use strict";
-// todoruleid: hardcoded-jwt-secret
+// ruleid: hardcoded-jwt-secret
 const jwt = require('jsonwebtoken');
 const Promise = require("bluebird");
 const secret = "hardcoded-secret"

--- a/javascript/jwt-hardcode/jwt-hardcode.yaml
+++ b/javascript/jwt-hardcode/jwt-hardcode.yaml
@@ -182,6 +182,9 @@ rules:
               var $KEY = JWK.asKey($SECRET);
               ...
               var $T = JWT.verify($P, $KEY, ...);
-    message: "hardcoded jwt secret"
+    message: |
+      Hardcoded JWT secret or private key is used.
+      This is a Insufficiently Protected Credentials weakness: https://cwe.mitre.org/data/definitions/522.html
+      Consider using an appropriate security mechanism to protect the credentials (e.g. keeping secrets in environment variables: process.env.SECRET)
     languages: [javascript]
     severity: ERROR

--- a/javascript/jwt-hardcode/jwt-hardcode.yaml
+++ b/javascript/jwt-hardcode/jwt-hardcode.yaml
@@ -1,68 +1,187 @@
-# module imports used as described in https://github.com/returntocorp/sgrep/issues/285
 rules:
   - id: hardcoded-jwt-secret
     patterns:
       - pattern-either:
+          # jsonwebtoken
           - pattern: |
-              $JWT = require("jsonwebtoken");
+              var $JWT = require("jsonwebtoken");
+              ...
+              var $T = $JWT.sign($P, "...", ...);
+          - pattern: |
+              var $JWT = require("jsonwebtoken");
+              ...
+              var $T = $JWT.verify($P, "...", ...);
+          - pattern: |
+              var $JWT = require("jsonwebtoken");
               ...
               $JWT.sign($P, "...", ...);
           - pattern: |
-              $JWT = require("jsonwebtoken");
+              var $JWT = require("jsonwebtoken");
               ...
               $JWT.verify($P, "...", ...);
           - pattern: |
-              $JWT = require("jsonwebtoken");
+              var $JWT = require("jsonwebtoken");
               ...
-              $SECRET = "...";
+              var $SECRET = "...";
+              ...
+              var $T = $JWT.sign($P, $SECRET, ...);
+          - pattern: |
+              var $JWT = require("jsonwebtoken");
+              ...
+              var $SECRET = "...";
+              ...
+              var $T = $JWT.verify($P, $SECRET, ...);
+          - pattern: |
+              var $JWT = require("jsonwebtoken");
+              ...
+              var $SECRET = "...";
               ...
               $JWT.sign($P, $SECRET, ...);
           - pattern: |
-              $JWT = require("jsonwebtoken");
+              var $JWT = require("jsonwebtoken");
               ...
-              $SECRET = "...";
+              var $SECRET = "...";
               ...
               $JWT.verify($P, $SECRET, ...);
+          # jose
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $JOSE.JWT.sign($P, "...", ...);
+              var { JWT } = $JOSE;
+              ...
+              JWT.verify($P, "...", ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $JOSE.JWT.verify($P, "...", ...);
+              var { JWT } = $JOSE;
+              ...
+              var $T = JWT.sign($P, "...", ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $JOSE.JWT.sign($P, $JOSE.JWK.asKey("..."), ...);
+              var { JWT } = $JOSE;
+              ...
+              var $T = JWT.verify($P, "...", ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $JOSE.JWT.verify($P, $JOSE.JWK.asKey("..."), ...);
+              var { JWK, JWT } = $JOSE;
+              ...
+              JWT.verify($P, JWK.asKey("..."), ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $SECRET = "...";
+              var { JWK, JWT } = $JOSE;
               ...
-              $JOSE.JWT.sign($P, $SECRET, ...);
+              var $KEY = JWK.asKey("...");
+              ...
+              JWT.verify($P, $KEY, ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $SECRET = "...";
+              var { JWK, JWT } = $JOSE;
               ...
-              $JOSE.JWT.verify($P, $SECRET, ...);
+              var $T = JWT.sign($P, JWK.asKey("..."), ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $SECRET = "...";
+              var { JWK, JWT } = $JOSE;
               ...
-              $JOSE.JWT.sign($P, $JOSE.JWK.asKey($SECRET), ...);
+              var $T = JWT.verify($P, JWK.asKey("..."), ...);
           - pattern: |
-              $JOSE = require("jose");
+              var $JOSE = require("jose");
               ...
-              $SECRET = "...";
+              var { JWK, JWT } = $JOSE;
               ...
-              $JOSE.JWT.verify($P, $JOSE.JWK.asKey($SECRET), ...);
+              var $KEY = JWK.asKey("...");
+              ...
+              var $T = JWT.sign($P, $KEY, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $KEY = JWK.asKey("...");
+              ...
+              var $T = JWT.verify($P, $KEY, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              JWT.verify($P, $SECRET, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $T = JWT.sign($P, $SECRET, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $T = JWT.verify($P, $SECRET, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              JWT.verify($P, JWK.asKey($SECRET), ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $KEY = JWK.asKey($SECRET);
+              ...
+              JWT.verify($P, $KEY, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $T = JWT.sign($P, JWK.asKey($SECRET), ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $KEY = JWK.asKey($SECRET);
+              ...
+              var $T = JWT.sign($P, $KEY, ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $T = JWT.verify($P, JWK.asKey($SECRET), ...);
+          - pattern: |
+              var $JOSE = require("jose");
+              ...
+              var { JWK, JWT } = $JOSE;
+              ...
+              var $SECRET = "...";
+              ...
+              var $KEY = JWK.asKey($SECRET);
+              ...
+              var $T = JWT.verify($P, $KEY, ...);
     message: "hardcoded jwt secret"
     languages: [javascript]
     severity: ERROR

--- a/javascript/jwt-hardcode/simple-examples.js
+++ b/javascript/jwt-hardcode/simple-examples.js
@@ -1,36 +1,91 @@
-const jsonwt = require('jsonwebtoken')
-const jose = require('jose')
-const { JWK, JWT } = jose
 const config = require('./config')
 
-const payload = {foo: 'bar'}
-const secret = 'shhhhh'
+function example1() {
+// ruleid: hardcoded-jwt-secret
+  const jsonwt = require('jsonwebtoken')
+  const payload = {foo: 'bar'}
+  const secret = 'shhhhh'
+  const token1 = jsonwt.sign(payload, secret)
+}
 
-const secret2 = config.secret
-const secret3 = process.env.SECRET || 'fallback-secret'
+function example2() {
+// ruleid: hardcoded-jwt-secret
+  const jsonwt = require('jsonwebtoken')
+  const payload = {foo: 'bar'}
+  const token2 = jsonwt.sign(payload, 'some-secret')
+}
 
-//jsonwebtoken
-//true
-const token1 = jsonwt.sign(payload, secret)
-//true
-const token2 = jsonwt.sign(payload, 'some-secret')
-//false
-const token3 = jsonwt.sign(payload, config.secret)
-//false
-const token4 = jsonwt.sign(payload, secret2)
-//??
-const token5 = jsonwt.sign(payload, secret3)
+function example3() {
+// ok
+  const jsonwt = require('jsonwebtoken')
+  const payload = {foo: 'bar'}
+  const token3 = jsonwt.sign(payload, config.secret)
+}
 
-//jose
-//true
-const token6 = JWT.sign(payload, JWK.asKey(secret))
-//true
-const token7 = JWT.sign(payload, JWK.asKey('raz-dva-tri'))
-//true
-const token8 = JWT.sign(payload, secret)
-//true
-const token9 = JWT.sign(payload, 'secret-again')
-//false
-const token11 = JWT.sign(payload, JWK.asKey(secret2))
-//false
-const token12 = JWT.sign(payload, secret2)
+function example4() {
+// ok
+  const jsonwt = require('jsonwebtoken')
+  const payload = {foo: 'bar'}
+  const secret2 = config.secret
+  const token4 = jsonwt.sign(payload, secret2)
+}
+
+function example5() {
+// ok
+  const jsonwt = require('jsonwebtoken')
+  const payload = {foo: 'bar'}
+  const secret3 = process.env.SECRET || 'fallback-secret'
+  const token5 = jsonwt.sign(payload, secret3)
+}
+
+function example6() {
+// ruleid: hardcoded-jwt-secret
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const secret = 'shhhhh'
+  const token6 = JWT.sign(payload, JWK.asKey(secret))
+}
+
+function example7() {
+// ruleid: hardcoded-jwt-secret
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const token7 = JWT.sign(payload, JWK.asKey('raz-dva-tri'))
+}
+
+function example8() {
+// ruleid: hardcoded-jwt-secret
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const secret = 'shhhhh'
+  const token8 = JWT.sign(payload, secret)
+}
+
+function example9() {
+// ruleid: hardcoded-jwt-secret
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const token9 = JWT.sign(payload, 'secret-again')
+}
+
+function example10() {
+// ok
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const secret2 = config.secret
+  const token11 = JWT.sign(payload, JWK.asKey(secret2))
+}
+
+function example11() {
+// ok
+  const jose = require('jose')
+  const { JWK, JWT } = jose
+  const payload = {foo: 'bar'}
+  const secret2 = config.secret
+  const token12 = JWT.sign(payload, secret2)
+}


### PR DESCRIPTION
Updating the rules according to https://github.com/returntocorp/sgrep/pull/333
and current state of module matching

now it tackles `simple-examples.js`

blocking task:
https://github.com/returntocorp/sgrep/issues/336

and there are few more tasks that not block the rule but will increase the coverage:
https://github.com/returntocorp/sgrep/issues/337
https://github.com/returntocorp/sgrep/issues/338