### PR TITLE
TLS blacklist rule

### DIFF
--- a/go/gosec/tls_ssl_blacklist/tls.go
+++ b/go/gosec/tls_ssl_blacklist/tls.go
@@ -1,0 +1,32 @@
+// Insecure ciphersuite selection
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	tr := &http.Transport{
+		// ruleid: tls-with-insecure-cipher
+		TLSClientConfig: &tls.Config{CipherSuites: []uint16{
+			tls.TLS_RSA_WITH_RC4_128_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		}},
+	}
+	client := &http.Client{Transport: tr}
+	_, err := client.Get("https://golang.org/")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	tr := &http.Transport{
+		// should be fine
+		TLSClientConfig: &tls.Config{CipherSuites: []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+		}},
+	}
+	client := &http.Client{Transport: tr}
+}

--- a/go/gosec/tls_ssl_blacklist/tls.go
+++ b/go/gosec/tls_ssl_blacklist/tls.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
+	// ruleid: tls-with-insecure-cipher
 	tr := &http.Transport{
-		// ruleid: tls-with-insecure-cipher
 		TLSClientConfig: &tls.Config{CipherSuites: []uint16{
 			tls.TLS_RSA_WITH_RC4_128_SHA,
 			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,

--- a/go/gosec/tls_ssl_blacklist/tls.yaml
+++ b/go/gosec/tls_ssl_blacklist/tls.yaml
@@ -1,0 +1,36 @@
+rules:
+  - id: tls-with-insecure-cipher
+    message:
+      CipherSuite configuration is insecure based on the tls package. 
+      See https://golang.org/pkg/crypto/tls/#InsecureCipherSuites for why and what other cipher suites to use.
+    metadata:
+      cwe: 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+      owasp: 'A9: Using Components with Known Vulnerabilities'
+      source_rule_url: https://github.com/securego/gosec/blob/master/rules/tls.go
+    languages: [go]
+    severity: WARNING
+    pattern-either:
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_RSA_WITH_RC4_128_SHA,...}}
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_RSA_WITH_AES_128_CBC_SHA256,...}}
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,...}}
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,...}}
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,...}}
+      - pattern: | 
+          tls.Config{..., CipherSuites: []$TYPE{..., tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,...}}
+      - pattern: |
+          tls.CipherSuite{..., TLS_RSA_WITH_RC4_128_SHA ,...}
+      - pattern: |
+          tls.CipherSuite{..., TLS_RSA_WITH_AES_128_CBC_SHA256 ,...}
+      - pattern: |
+          tls.CipherSuite{..., TLS_ECDHE_ECDSA_WITH_RC4_128_SHA ,...}
+      - pattern: |
+          tls.CipherSuite{..., TLS_ECDHE_RSA_WITH_RC4_128_SHA ,...}
+      - pattern: |
+          tls.CipherSuite{..., TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 ,...}
+      - pattern: |
+          tls.CipherSuite{..., TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 ,...}


### PR DESCRIPTION
The blacklist is based on the recommendation of the pkg maintainer:
https://golang.org/src/crypto/tls/cipher_suites.go?s=3635:3677#L71