### PR TITLE
Port over G106

### DIFF
--- a/go/gosec/bad_imports/insecure_ssh.go
+++ b/go/gosec/bad_imports/insecure_ssh.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"golang.org/x/crypto/ssh"
+)
+
+func main() {
+	// ruleid: avoid-ssh-insecure-ignore-host-key
+	_ = ssh.InsecureIgnoreHostKey()
+}

--- a/go/gosec/bad_imports/insecure_ssh.go
+++ b/go/gosec/bad_imports/insecure_ssh.go
@@ -4,6 +4,19 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func ok() {
+	var publicKey *rsa.PublicKey
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKey = &privateKey.PublicKey
+	hostKey, _ := ssh.NewPublicKey(publicKey)
+	// ok
+	_ = ssh.FixedHostKey(hostKey);
+}
+
 func main() {
 	// ruleid: avoid-ssh-insecure-ignore-host-key
 	_ = ssh.InsecureIgnoreHostKey()

--- a/go/gosec/bad_imports/insecure_ssh.yaml
+++ b/go/gosec/bad_imports/insecure_ssh.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: avoid-ssh-insecure-ignore-host-key
+    message: Disabling host key verification is discouraged. 
+      See https://skarlso.github.io/2019/02/17/go-ssh-with-host-key-verification/ to learn
+      more about the problem and how to fix it.
+    metadata:
+      cwe: 'CWE-322: Key Exchange without Entity Authentication'
+      source_rule_url: https://github.com/securego/gosec
+    languages: [go]
+    severity: WARNING
+    pattern: |
+        ssh.InsecureIgnoreHostKey()


### PR DESCRIPTION
Based on https://skarlso.github.io/2019/02/17/go-ssh-with-host-key-verification/,
its worth highlighting this check.