### PR TITLE
semgrep --lint is clean now

### DIFF
--- a/python/django/security/injection/reflected-data-httpresponse.yaml
+++ b/python/django/security/injection/reflected-data-httpresponse.yaml
@@ -243,3 +243,9 @@ rules:
             $INTERM = $STR + $DATA
             ...
             django.http.HttpResponse(..., $INTERM, ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $INTERM = $STR + $DATA
+            ...
+            django.http.HttpResponse(..., $INTERM, ...)

--- a/python/flask/security/open-redirect.yaml
+++ b/python/flask/security/open-redirect.yaml
@@ -11,49 +11,17 @@ rules:
             ...
             flask.redirect($V, ...)
         - pattern: |
-            $V = flask.request.$W.get($X)
-            ...
-            $Z = flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W.get($X)
-            ...
-            return flask.redirect($V, ...)
-        - pattern: |
             $V = flask.request.$W[$X]
             ...
             flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W[$X]
-            ...
-            $Z = flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W[$X]
-            ...
-            return flask.redirect($V, ...)
         - pattern: |
             $V = flask.request.$W($X)
             ...
             flask.redirect($V, ...)
         - pattern: |
-            $V = flask.request.$W($X)
-            ...
-            $Z = flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W($X)
-            ...
-            return flask.redirect($V, ...)
-        - pattern: |
             $V = flask.request.$W
             ...
             flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W
-            ...
-            $Z = flask.redirect($V, ...)
-        - pattern: |
-            $V = flask.request.$W
-            ...
-            return flask.redirect($V, ...)
     message: |
         Data from request is passed to redirect().
         This is an open redirect and could be exploited.

--- a/python/flask/security/render-template-string.yaml
+++ b/python/flask/security/render-template-string.yaml
@@ -5,11 +5,7 @@ rules:
         - pattern: |
             $V = "...".format(...)
             ...
-            $T = flask.render_template_string($V, ...)
-        - pattern: |
-            $V = "...".format(...)
-            ...
-            return flask.render_template_string($V, ...)
+            flask.render_template_string($V, ...)
         - pattern: |
             $V = "...".format(...)
             ...
@@ -17,11 +13,7 @@ rules:
         - pattern: |
             $V = "..." % $S
             ...
-            $T = flask.render_template_string($V, ...)
-        - pattern: |
-            $V = "..." % $S
-            ...
-            return flask.render_template_string($V, ...)
+            flask.render_template_string($V, ...)
         - pattern: |
             $V = "..." % $S
             ...
@@ -31,13 +23,7 @@ rules:
             ...
             $V += $O
             ...
-            $T = flask.render_template_string($V, ...)
-        - pattern: |
-            $V = "..."
-            ...
-            $V += $O
-            ...
-            return flask.render_template_string($V, ...)
+            flask.render_template_string($V, ...)
         - pattern: |
             $V = "..."
             ...
@@ -47,11 +33,7 @@ rules:
         - pattern: |
             $V = f"...{$X}..."
             ...
-            $T = flask.render_template_string($V, ...)
-        - pattern: |
-            $V = f"...{$X}..."
-            ...
-            return flask.render_template_string($V, ...)
+            flask.render_template_string($V, ...)
         - pattern: |
             $V = f"...{$X}..."
             ...

--- a/python/flask/security/unsanitized_input.yaml
+++ b/python/flask/security/unsanitized_input.yaml
@@ -5,35 +5,19 @@ rules:
           - pattern: |
               $X = request.args.get(...)
               ...
-              return flask.make_response("...".format($X))
+              flask.make_response("...".format($X))
           - pattern: |
               $X = request.args.get(...)
               ...
-              $R = flask.make_response("...".format($X))
+              flask.make_response(f"...{$X}...")
           - pattern: |
               $X = request.args.get(...)
               ...
-              return flask.make_response(f"...{$X}...")
+              flask.make_response(f"...{$X}")
           - pattern: |
               $X = request.args.get(...)
               ...
-              $R = flask.make_response(f"...{$X}...")
-          - pattern: |
-              $X = request.args.get(...)
-              ...
-              return flask.make_response(f"...{$X}")
-          - pattern: |
-              $X = request.args.get(...)
-              ...
-              $R = flask.make_response(f"...{$X}")
-          - pattern: |
-              $X = request.args.get(...)
-              ...
-              return flask.make_response(f"{$X}...")
-          - pattern: |
-              $X = request.args.get(...)
-              ...
-              $R = flask.make_response(f"{$X}...")
+              flask.make_response(f"{$X}...")
     message: |
       Flask response reflects unsanitized user input. This could lead to a
       cross-site scripting vulnerability (https://owasp.org/www-community/attacks/xss/)


### PR DESCRIPTION
Cleanup all cases of matching `return`, `$A =` as detected by `semgrep --lint`